### PR TITLE
Change circleci/aws-cli orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-cli: circleci/aws-cli@2.0.3
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:


### PR DESCRIPTION
Changed aws-cli orb version  from 0.1.9 to 2.0.3 due to unsupported Python version.