### PR TITLE
Add VPC and Subnet to serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,9 +5,16 @@ provider:
   stage: ${opt:stage}
   region: eu-west-2
   timeout: 30
+  apiGateway:
+    shouldStartNameWithService: true
+  tracing:
+    apiGateway: true
+    lambda: true
+    vpc:
+      securityGroupIds: ${self:custom.securityGroups.${self:provider.stage}}
+      subnetIds: ${self:custom.subnets.${self:provider.stage}}
   environment:
     BUCKET_NAME: comino-document-retrieval-${self:provider.stage}-documents
- 
   s3:
   documentsBucket:
     accessControl: Private
@@ -115,3 +122,28 @@ resources:
                 Effect: "Allow"
                 Resource:
                   - "arn:aws:s3:::${self:provider.environment.BUCKET_NAME}/*"
+
+# custom:
+#   domain-name:
+#     Fn::Join:
+#       - '.'
+#       - - Ref: ApiGatewayRestApi
+#         - execute-api
+#         - eu-west-2
+#         - amazonaws.com
+#   alias: ${ssm:/comino-document-retrieval/${self:provider.stage}/client-url}
+#   certificate-arn:
+#     staging: arn:aws:acm:us-east-1:549011513230:certificate/d49e84b5-5ed2-4d35-87f3-7d10f848ee6b
+#     production: arn:aws:acm:us-east-1:658402009206:certificate/06d017f3-c883-49aa-8af8-e4398fa03286
+#   securityGroups:
+#     staging:
+#       - sg-012b551e32735b814
+#     # production:
+#     #   - sg-0cd04f47325eca077
+#   subnets:
+#     staging:
+#       - subnet-0aa5f484db1aa801c
+#       - subnet-012870b02db9a3bf8
+#     # production:
+#     #   - subnet-0a00b445652b2d8e8
+#     #   - subnet-0c31b6c3961a84548


### PR DESCRIPTION
Add VPC and Subnet configuration to the serverless.yml file, so that requests can be forwarded throw the VPC in order to stop obtaining access denied errors 