### PR TITLE
Fix typo in serverless config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -125,5 +125,5 @@ custom:
     staging:
       securityGroupIds:
         - sg-091049a0c605ae673
-      subnetsIds:
+      subnetIds:
         - subnet-0acfea27bdd1e237e


### PR DESCRIPTION
Fixed a typo in serverless config that possibly blocked the lambda from deploying into the VPC