### PR TITLE
Change format of file to xml in index.js to verify its content

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -18,12 +18,12 @@ app.get("/download/:id", async (req, res, next) => {
   try {
     const response = await downloadDocument(req.params.id);
 
-    const fileExt = W2DocExtensionLookup["msg"] || "msg";
+    const fileExt = W2DocExtensionLookup["xml"] || "xml";
     const mimeType = mimeTypes.lookup(fileExt) || "application/octet-stream";
 
 
     res.set('Content-Type', mimeType);
-    res.set('Content-Disposition', `attachment; filename="${req.params.id}.msg"`);
+    res.set('Content-Disposition', `attachment; filename="${req.params.id}.xml"`);
     res.send(response);
   } catch (err) {
     console.log("Download failed", { error: err });


### PR DESCRIPTION
Change format of file to xml in index.js to be able to open its content and verify if it converted the file correctly to a new extension