### PR TITLE
Fix database variable to string type

### DIFF
--- a/api/lib/SqlServerConnection.js
+++ b/api/lib/SqlServerConnection.js
@@ -7,7 +7,7 @@ module.exports = (options) => {
     user: dbUrl.username,
     password: dbUrl.password,
     server: dbUrl.host,
-    database: dbUrl.path,
+    database: dbUrl.path[0],
     requestTimeout: 60000,
   };
 


### PR DESCRIPTION
Changed database type from array with 1 position, to a string in order to solve the error:
TypeError: The "config.options.database" property must be of type string.