### PR TITLE
Cap serverless version to v3 to stay under the old license.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,12 +168,12 @@ workflows:
             branches:
               only:
                 - main
-      - ssh-jumpbox-staging:
-          requires:
-            - assume-role-staging
+      # - ssh-jumpbox-staging:
+      #     requires:
+      #       - assume-role-staging
       - deploy-staging:
           requires:
-            - ssh-jumpbox-staging
+            - assume-role-staging
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
       - install-node
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Install dependencies
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Install serverless CLI
-          command: sudo npm i -g serverless
+          command: sudo npm i -g serverless@^3
       - run:
           name: Install dependencies
           command: npm install


### PR DESCRIPTION
# What:
 - Cap serverless version to v3.
 - Also disable the SSH for migration step.

# Why:
 - The current default v4 forces a paid license, for more info see PR [[link](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/140)].
 - The database was destroyed.