### PR TITLE
Remove unused staging resources (haven't been used since 2022).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
           root: *workspace_root
           paths:
             - .aws
-  deploy-lambda:
+  destroy-resources:
     description: "Deploys application"
     parameters:
       stage:
@@ -54,7 +54,7 @@ commands:
       - run:
           name: Deploy lambda
           command: |
-            sls deploy -s <<parameters.stage>>
+            sls remove -s <<parameters.stage>>
 
   ssh-into-jumpbox:
     description: "SSH into jumpbox to connect to the database"
@@ -144,7 +144,7 @@ jobs:
       #     name: Deploy application
       #     command: |
       #       ./node_modules/serverless/bin/serverless deploy -s staging --config serverless.yml
-      - deploy-lambda:
+      - destroy-resources:
           stage: staging
 
 workflows:


### PR DESCRIPTION
# What:
 - Trigger `Document-Platform-Staging` environment resource destruction.

# Why:
 - These resources haven't been in use since 2022.
 - The S3 bucket is as almost empty at ~2.5MB containing a bunch of dummy files (just what you'd expect from PoC).

# Notes:
 - This application was a proof of concept work which explains the lack of production environment [[doc 1](https://docs.google.com/document/d/1BmdITT4dq37-8YFWPaEYNFGIU6oND7IqmVFjCYNek9I/edit)]
 - We have also found that comino related documents have been moved to a different account [[doc 2](https://docs.google.com/document/d/1AnCvkEUZwHM07V2hFcl2tIK8PUfZPoCZ/edit)].
 - The database's terraform is within another repository & is getting removed as part of this [[link](https://github.com/LBHackney-IT/infrastructure/pull/2050)] PR.
 - The S3 files were backed up within Google Drive & described within the [[doc3](https://docs.google.com/document/d/1Y1E5SsDHIBg8smXFFqhFIdxQdk2h6u7u-3NSgPy3OmM/edit)].

# Screenshots:

| Lambda haven't been used since 2022 |
| --- |
| ![image](https://github.com/user-attachments/assets/821708b4-3cc2-4e0a-914f-345cc5566978) |