### PR TITLE
Upgraded node version & executor docker image repository.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: circleci/node:14.2
+      - image: cimg/node:20.16
     working_directory: ~/repo
   python:
     docker:


### PR DESCRIPTION
# What:
 - Re-point pipeline's node executor to the non-deprecated dockerhub target _(`circleci` -> `cimg`)_.
 - Update node version.

# Why:
 - Abandoned dockerhub `circleci` repository does not have new enough node versions available.
 - So that the most recent serverless version don't fail.