### PR TITLE
Switch the pipeline to Alpine to drop the bloat.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
       - install-node
       - run:
           name: Install serverless CLI
-          command: sudo npm i -g serverless
+          command: npm i -g serverless
       - run:
           name: Install dependencies
           command: npm install
@@ -75,7 +75,7 @@ commands:
       - setup_remote_docker
       # - run:
       #     name: Install Unzip
-      #     command: sudo apt-get update && sudo apt-get install unzip
+      #     command: apt-get update && apt-get install unzip
       # - run:
       #     name: Install AWS CLI
       #     command: |
@@ -84,16 +84,16 @@ commands:
       #       ./aws/install
       - run:
           name: Install AWS CLI
-          # command: sudo apt-get update && sudo apt-get install -y awscli
+          # command: apt-get update && apt-get install -y awscli
           command: |
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
-            sudo ./aws/install
+            ./aws/install
       - run:
           name: Install Session Manager plugin
           command: |
             curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-            sudo dpkg -i session-manager-plugin.deb
+            dpkg -i session-manager-plugin.deb
       # - run:
       #     name: SSH into database
       #     command: |
@@ -120,8 +120,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo npm i --no-cache git
-            sudo npm i
+            npm i --no-cache git
+            npm i
 
       # - run:
       #     name: Run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:20.16
+      - image: alpine:latest
     working_directory: ~/repo
   python:
     docker:
@@ -20,6 +20,13 @@ references:
       at: *workspace_root
 
 commands:
+  install-node:
+    description: "Installs NPM and Node.js"
+    steps:
+      - run:
+          name: Install npm and node
+          command: apk add --update nodejs npm
+
   assume-role-and-persist-workspace:
     description: "Assumes deployment role and persists credentials across jobs"
     parameters:
@@ -45,6 +52,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
+      - install-node
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -108,7 +116,7 @@ jobs:
       NODE_ENV: ci
     steps:
       - checkout
-
+      - install-node
       - run:
           name: Install dependencies
           command: |


### PR DESCRIPTION
# What:
 - Ditched the CircleCI's "convenience" images.
 - Switched the pipeline to run on Alpine linux.

# Why:
 - CircleCI "convenience" _(probably just the trademark name or something)_ are actually as inconvenient as gets.
 - Tried sticking with Ubuntu, but by doing so you're forced to mess about with the image's environment too much.

# Notes:
 - There's still a bunch of left-over litter to clean up from the when the project was still active.

| Old pipeline | New pipeline |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/9a04ec51-a75f-4219-9ecf-90ad6b1527b8) | ![image](https://github.com/user-attachments/assets/f1567c43-b478-4dcb-a5bc-69c7f8a92873) |